### PR TITLE
SolSA plugin for ArgoCD

### DIFF
--- a/generic/tools/argocd_release/charts/solsa-cm/.helmignore
+++ b/generic/tools/argocd_release/charts/solsa-cm/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/generic/tools/argocd_release/charts/solsa-cm/Chart.yaml
+++ b/generic/tools/argocd_release/charts/solsa-cm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: solsa-cm
+version: 0.1.0

--- a/generic/tools/argocd_release/charts/solsa-cm/templates/_helpers.tpl
+++ b/generic/tools/argocd_release/charts/solsa-cm/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "solsa-cm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "solsa-cm.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "solsa-cm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "solsa-cm.labels" -}}
+app.kubernetes.io/name: {{ include "solsa-cm.name" . }}
+helm.sh/chart: {{ include "solsa-cm.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/generic/tools/argocd_release/charts/solsa-cm/templates/solsa-cm.yaml
+++ b/generic/tools/argocd_release/charts/solsa-cm/templates/solsa-cm.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: solsa-cm
+  labels:
+    "app.kubernetes.io/name": "argocd"
+    "app.kubernetes.io/instance": "argocd"
+    group: {{ .Values.group | quote }}
+data:
+  solsa.yaml: |
+    clusters:
+    - name: 'in-cluster'
+      ingress:
+        iks:
+          subdomain: {{ .Values.ingress.subdomain | quote }}
+          tlssecret: {{ .Values.ingress.tlssecret | quote }}
+    contexts:
+    - name: 'in-cluster-context'
+      cluster: 'in-cluster'

--- a/generic/tools/argocd_release/charts/solsa-cm/values.yaml
+++ b/generic/tools/argocd_release/charts/solsa-cm/values.yaml
@@ -1,0 +1,6 @@
+
+group: catalyst-tools
+
+ingress:
+  subdomain: ""
+  tlssecret: ""

--- a/generic/tools/argocd_release/kustomize/argocd/kustomization.yaml
+++ b/generic/tools/argocd_release/kustomize/argocd/kustomization.yaml
@@ -3,3 +3,7 @@ commonLabels:
 resources:
  - base.yaml
  - access.yaml
+ - solsa/solsa-cm.yaml
+patchesStrategicMerge:
+ - solsa/argocd-reposerver.yaml
+ - solsa/argocd-cm.yaml

--- a/generic/tools/argocd_release/kustomize/argocd/solsa/argocd-cm.yaml
+++ b/generic/tools/argocd_release/kustomize/argocd/solsa/argocd-cm.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  configManagementPlugins: |
+    - name: solsa
+      generate:
+        command: [sh, -c]
+        args: ["/solsa/solsa/node_modules/solsa/solsa yaml $SOLSA_APP_MAIN --config /solsa/solsa-config/solsa.yaml --cluster ${SOLSA_CLUSTER:-in-cluster} --context ${SOLSA_CONTEXT:-in-cluster-context} $SOLSA_EXTRA_ARGS"]

--- a/generic/tools/argocd_release/kustomize/argocd/solsa/argocd-reposerver.yaml
+++ b/generic/tools/argocd_release/kustomize/argocd/solsa/argocd-reposerver.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-repo-server
+spec:
+  template:
+    spec:
+      volumes:
+      - name: solsa-install
+        emptyDir: {}
+      - name: solsa-config
+        configMap:
+          name: solsa-cm
+      initContainers:
+      - name: solsa-install
+        image: node:10
+        command: [sh, -c]
+        args:
+        - mkdir /tmp/home && export HOME=/tmp/home && cd /solsa && npm install pkg && npm install solsa && cd node_modules/solsa && ../.bin/pkg . -t host
+        volumeMounts:
+        - mountPath: /solsa
+          name: solsa-install
+      containers:
+      - name: repo-server
+        volumeMounts:
+        - mountPath: /solsa/solsa
+          name: solsa-install
+        - mountPath: /solsa/solsa-config
+          name: solsa-config

--- a/generic/tools/argocd_release/kustomize/argocd/solsa/solsa-cm.yaml
+++ b/generic/tools/argocd_release/kustomize/argocd/solsa/solsa-cm.yaml
@@ -1,0 +1,1 @@
+# Generated from helm template

--- a/generic/tools/argocd_release/main.tf
+++ b/generic/tools/argocd_release/main.tf
@@ -2,6 +2,8 @@ locals {
   tmp_dir      = "${path.cwd}/.tmp"
   chart_name   = "argo-cd"
   ingress_host = "argocd.${var.cluster_ingress_hostname}"
+  ingress_subdomain = "${var.cluster_ingress_hostname}"
+  ingress_tlssecret = "${var.tls_secret_name}"
   ingress_url  = "http://${local.ingress_host}"
   config_name  = "argocd-config"
   secret_name  = "argocd-access"
@@ -9,7 +11,7 @@ locals {
 
 resource "null_resource" "argocd_release" {
   provisioner "local-exec" {
-    command = "${path.module}/scripts/deploy-argocd.sh ${local.chart_name} ${var.releases_namespace} ${var.helm_version} ${local.ingress_host}"
+    command = "${path.module}/scripts/deploy-argocd.sh ${local.chart_name} ${var.releases_namespace} ${var.helm_version} ${local.ingress_host} ${local.ingress_subdomain} ${local.ingress_tlssecret}"
 
     environment = {
       KUBECONFIG_IKS  = "${var.cluster_config_file}"

--- a/generic/tools/argocd_release/scripts/deploy-argocd.sh
+++ b/generic/tools/argocd_release/scripts/deploy-argocd.sh
@@ -7,6 +7,8 @@ CHART_NAME="$1"
 NAMESPACE="$2"
 VERSION="$3"
 INGRESS_HOST="$4"
+INGRESS_SUBDOMAIN="$5"
+INGRESS_TLSSECRET="$6"
 
 if [[ -n "${KUBECONFIG_IKS}" ]]; then
     export KUBECONFIG="${KUBECONFIG_IKS}"
@@ -25,10 +27,12 @@ KUSTOMIZE_PATCH="${KUSTOMIZE_DIR}/argocd/patch-ingress.yaml"
 
 ARGOCD_CHART="${CHART_DIR}/${CHART_NAME}"
 ACCESS_CHART="${MODULE_DIR}/charts/argocd-access"
+SOLSACM_CHART="${MODULE_DIR}/charts/solsa-cm"
 
 ARGOCD_KUSTOMIZE="${KUSTOMIZE_DIR}/argocd"
 ARGOCD_BASE_KUSTOMIZE="${ARGOCD_KUSTOMIZE}/base.yaml"
 ARGOCD_ACCESS_KUSTOMIZE="${ARGOCD_KUSTOMIZE}/access.yaml"
+ARGOCD_SOLSACM_KUSTOMIZE="${ARGOCD_KUSTOMIZE}/solsa/solsa-cm.yaml"
 
 ARGOCD_YAML="${TMP_DIR}/argocd.yaml"
 
@@ -62,6 +66,12 @@ echo "*** Generating access yaml from helm template into ${ARGOCD_ACCESS_KUSTOMI
 helm template ${ACCESS_CHART} \
     --namespace ${NAMESPACE} \
     --set url="http://${INGRESS_HOST}" > ${ARGOCD_ACCESS_KUSTOMIZE}
+
+echo "*** Generating solsa-cm yaml from helm template into ${ARGOCD_SOLSACM_KUSTOMIZE}"
+helm template ${SOLSACM_CHART} \
+    --namespace ${NAMESPACE} \
+    --set ingress.subdomain="${INGRESS_SUBDOMAIN}" \
+    --set ingress.tlssecret="${INGRESS_TLSSECRET}" > ${ARGOCD_SOLSACM_KUSTOMIZE}
 
 echo "*** Building final kube yaml from kustomize into ${ARGOCD_YAML}"
 kustomize build "${ARGOCD_KUSTOMIZE}" > "${ARGOCD_YAML}"


### PR DESCRIPTION
Extend ArgoCD with a SolSA plugin.

NOTE: This PR is **NOT** ready to be merged; it is being posted for initial review.

We first need to merge https://github.com/ibm-garage-cloud/argo-helm/pull/2 to update the ArgoCD version and then remove the change in this PR in `deploy-argocd.sh` that gets the ArgoCD Helm chart from https://dgrove-oss.github.io/argo-helm/ instead of https://ibm-garage-cloud.github.io/argo-helm/