### PR TITLE
Lowercase container registry namespace name

### DIFF
--- a/cloud-managed/cluster/ibmcloud/scripts/create-registry-namespace.sh
+++ b/cloud-managed/cluster/ibmcloud/scripts/create-registry-namespace.sh
@@ -5,6 +5,7 @@ REGION="$2"
 
 # The name of a registry namespace cannot contain uppercase characters
 # Lowercase the resource group name, just in case...
+echo "Lowercasing the name of the resource group"
 REGISTRY_NAMESPACE=$(echo "$RESOURCE_GROUP" | tr '[:upper:]' '[:lower:]')
 
 ibmcloud login --apikey "${APIKEY}" -g "${RESOURCE_GROUP}" -r "${REGION}" 1> /dev/null 2> /dev/null

--- a/cloud-managed/cluster/ibmcloud/scripts/create-registry-namespace.sh
+++ b/cloud-managed/cluster/ibmcloud/scripts/create-registry-namespace.sh
@@ -5,7 +5,6 @@ REGION="$2"
 
 # The name of a registry namespace cannot contain uppercase characters
 # Lowercase the resource group name, just in case...
-echo "Lowercasing the name of the resource group"
 REGISTRY_NAMESPACE=$(echo "$RESOURCE_GROUP" | tr '[:upper:]' '[:lower:]')
 
 ibmcloud login --apikey "${APIKEY}" -g "${RESOURCE_GROUP}" -r "${REGION}" 1> /dev/null 2> /dev/null

--- a/cloud-managed/cluster/ibmcloud/scripts/create-registry-namespace.sh
+++ b/cloud-managed/cluster/ibmcloud/scripts/create-registry-namespace.sh
@@ -3,7 +3,9 @@
 RESOURCE_GROUP="$1"
 REGION="$2"
 
-REGISTRY_NAMESPACE="${RESOURCE_GROUP}"
+# The name of a registry namespace cannot contain uppercase characters
+# Lowercase the resource group name, just in case...
+REGISTRY_NAMESPACE=$(echo "$RESOURCE_GROUP" | tr '[:upper:]' '[:lower:]')
 
 ibmcloud login --apikey "${APIKEY}" -g "${RESOURCE_GROUP}" -r "${REGION}" 1> /dev/null 2> /dev/null
 if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
By default, the name of the registry namespace is taken from the name of the resource group. 

In case the resource group name contains uppercase chars, the container registry namespace creation fails because uppercase chars are not allowed.