### PR TITLE
Enable redis in argocd to workaround upsteam bug.

### DIFF
--- a/generic/tools/argocd_release/main.tf
+++ b/generic/tools/argocd_release/main.tf
@@ -1,6 +1,7 @@
 locals {
   tmp_dir      = "${path.cwd}/.tmp"
   chart_name   = "argo-cd"
+  enable_cache = "${var.enable_cache}"
   ingress_host = "argocd.${var.cluster_ingress_hostname}"
   ingress_subdomain = "${var.cluster_ingress_hostname}"
   ingress_tlssecret = "${var.tls_secret_name}"
@@ -11,7 +12,7 @@ locals {
 
 resource "null_resource" "argocd_release" {
   provisioner "local-exec" {
-    command = "${path.module}/scripts/deploy-argocd.sh ${local.chart_name} ${var.releases_namespace} ${var.helm_version} ${local.ingress_host} ${local.ingress_subdomain} ${local.ingress_tlssecret}"
+    command = "${path.module}/scripts/deploy-argocd.sh ${local.chart_name} ${var.releases_namespace} ${var.helm_version} ${local.ingress_host} ${local.ingress_subdomain} ${local.ingress_tlssecret} ${local.enable_cache}"
 
     environment = {
       KUBECONFIG_IKS  = "${var.cluster_config_file}"

--- a/generic/tools/argocd_release/scripts/deploy-argocd.sh
+++ b/generic/tools/argocd_release/scripts/deploy-argocd.sh
@@ -51,7 +51,8 @@ echo "*** Setting up kustomize directory"
 mkdir -p "${KUSTOMIZE_DIR}"
 cp -R "${KUSTOMIZE_TEMPLATE}" "${KUSTOMIZE_DIR}"
 
-HELM_VALUES="server.ingress.enabled=true,server.ingress.hosts.0=${INGRESS_HOST}"
+# Setting redis.enabled=true to workaround upstream bug: https://github.com/argoproj/argo-helm/issues/157
+HELM_VALUES="server.ingress.enabled=true,server.ingress.hosts.0=${INGRESS_HOST},redis.enabled=true"
 if [[ -n "${TLS_SECRET_NAME}" ]]; then
   HELM_VALUES="${HELM_VALUES},server.ingress.tls.0.secretName=${TLS_SECRET_NAME},server.ingress.tls.0.hosts.0=${INGRESS_HOST}"
 fi

--- a/generic/tools/argocd_release/scripts/deploy-argocd.sh
+++ b/generic/tools/argocd_release/scripts/deploy-argocd.sh
@@ -9,6 +9,7 @@ VERSION="$3"
 INGRESS_HOST="$4"
 INGRESS_SUBDOMAIN="$5"
 INGRESS_TLSSECRET="$6"
+ENABLE_ARGO_CACHE="$7"
 
 if [[ -n "${KUBECONFIG_IKS}" ]]; then
     export KUBECONFIG="${KUBECONFIG_IKS}"
@@ -51,8 +52,7 @@ echo "*** Setting up kustomize directory"
 mkdir -p "${KUSTOMIZE_DIR}"
 cp -R "${KUSTOMIZE_TEMPLATE}" "${KUSTOMIZE_DIR}"
 
-# Setting redis.enabled=true to workaround upstream bug: https://github.com/argoproj/argo-helm/issues/157
-HELM_VALUES="server.ingress.enabled=true,server.ingress.hosts.0=${INGRESS_HOST},redis.enabled=true"
+HELM_VALUES="server.ingress.enabled=true,server.ingress.hosts.0=${INGRESS_HOST},redis.enabled=${ENABLE_ARGO_CACHE}"
 if [[ -n "${TLS_SECRET_NAME}" ]]; then
   HELM_VALUES="${HELM_VALUES},server.ingress.tls.0.secretName=${TLS_SECRET_NAME},server.ingress.tls.0.hosts.0=${INGRESS_HOST}"
 fi

--- a/generic/tools/argocd_release/variables.tf
+++ b/generic/tools/argocd_release/variables.tf
@@ -26,3 +26,11 @@ variable "helm_version" {
   description = "The version of helm chart that should be deployed"
   default     = "1.0.0"
 }
+
+# If enable_cache is not set to true, then Argo will not be able to synchronize
+# deployed resources or display the YAML it generated for them.
+# See upstream bug: https://github.com/argoproj/argo-helm/issues/157
+variable "enable_cache" {
+  description = "Enable redis caching layer in Argo CD deployment"
+  default     = "true"
+}


### PR DESCRIPTION
Workaround upstream issue https://github.com/argoproj/argo-helm/issues/157
by setting redis.enabled to true when generating yaml from argo
helm chart.