### PR TITLE
ArgoCD module: upgrades to helm chart 1.8.7 (argocd image 1.4.2)

### DIFF
--- a/generic/tools/argocd_release/kustomize/argocd/kustomization.yaml
+++ b/generic/tools/argocd_release/kustomize/argocd/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
 patchesStrategicMerge:
  - solsa/argocd-reposerver.yaml
  - solsa/argocd-cm.yaml
+patchesJson6902:
+ - path: patch-dex-deployment.yaml
+   target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: argocd-dex-server

--- a/generic/tools/argocd_release/kustomize/argocd/patch-dex-deployment.yaml
+++ b/generic/tools/argocd_release/kustomize/argocd/patch-dex-deployment.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/template/spec/containers/0/image
+  value: "quay.io/dexidp/dex:v2.21.0"

--- a/generic/tools/argocd_release/main.tf
+++ b/generic/tools/argocd_release/main.tf
@@ -2,7 +2,7 @@ locals {
   tmp_dir      = "${path.cwd}/.tmp"
   chart_name   = "argo-cd"
   enable_cache = var.enable_cache
-  ingress_host = "argocd.${var.cluster_ingress_hostname}"
+  ingress_host = "argocd"
   ingress_subdomain = var.cluster_ingress_hostname
   ingress_url  = "http://${local.ingress_host}"
   config_name  = "argocd-config"

--- a/generic/tools/argocd_release/scripts/deploy-argocd.sh
+++ b/generic/tools/argocd_release/scripts/deploy-argocd.sh
@@ -33,17 +33,9 @@ ARGOCD_BASE_KUSTOMIZE="${ARGOCD_KUSTOMIZE}/base.yaml"
 ARGOCD_SOLSACM_KUSTOMIZE="${ARGOCD_KUSTOMIZE}/solsa/solsa-cm.yaml"
 
 ARGOCD_YAML="${TMP_DIR}/argocd.yaml"
+SECRET_OUTPUT_YAML="${TMP_DIR}/argocd-secret.yaml"
 
-HELM_REPO="https://ibm-garage-cloud.github.io/argo-helm/"
-
-echo "*** Fetching the helm chart from ${HELM_REPO}"
-mkdir -p ${CHART_DIR}
-helm init --client-only
-helm fetch --repo ${HELM_REPO} \
-    --untar \
-    --untardir ${CHART_DIR} \
-    --version ${VERSION} \
-    ${CHART_NAME}
+HELM_REPO="https://argoproj.github.io/argo-helm/"
 
 echo "*** Setting up kustomize directory"
 mkdir -p "${KUSTOMIZE_DIR}"
@@ -52,23 +44,27 @@ cp -R "${KUSTOMIZE_TEMPLATE}" "${KUSTOMIZE_DIR}"
 HELM_VALUES="redis.enabled=${ENABLE_ARGO_CACHE}"
 if [[ "${CLUSTER_TYPE}" == "kubernetes" ]]; then
   HELM_VALUES="${HELM_VALUES},server.ingress.enabled=true,server.ingress.hosts.0=${INGRESS_HOST}"
-  URL="http://${INGRESS_HOST}"
+  URL="http://${INGRESS_HOST}.${INGRESS_SUBDOMAIN}"
 
   if [[ -n "${TLS_SECRET_NAME}" ]]; then
-    HELM_VALUES="${HELM_VALUES},server.ingress.tls.0.secretName=${TLS_SECRET_NAME},server.ingress.tls.0.hosts.0=${INGRESS_HOST}"
-    URL="https://${INGRESS_HOST}"
+    HELM_VALUES="${HELM_VALUES},server.ingress.tls.0.secretName=${TLS_SECRET_NAME},server.ingress.tls.0.hosts.0=${INGRESS_HOST}.${INGRESS_SUBDOMAIN}"
+    URL="https://${INGRESS_HOST}.${INGRESS_SUBDOMAIN}"
   fi
 fi
 
+helm3 repo add argo ${HELM_REPO}
+
 echo "*** Generating kube yaml from helm template into ${ARGOCD_BASE_KUSTOMIZE}"
-helm template "${ARGOCD_CHART}" \
+helm3 template argocd "argo/${CHART_NAME}" \
+    --include-crds \
+    --version "${VERSION}" \
     --namespace "${NAMESPACE}" \
-    --name "argocd" \
+    --set installCRDs=false \
     --set "${HELM_VALUES}" > ${ARGOCD_BASE_KUSTOMIZE}
 
 echo "*** Generating solsa-cm yaml from helm template into ${ARGOCD_SOLSACM_KUSTOMIZE}"
-helm template ${SOLSACM_CHART} \
-    --namespace ${NAMESPACE} \
+helm3 template solsacm "${SOLSACM_CHART}" \
+    --namespace "${NAMESPACE}" \
     --set ingress.subdomain="${INGRESS_SUBDOMAIN}" \
     --set ingress.tlssecret="${TLS_SECRET_NAME}" > ${ARGOCD_SOLSACM_KUSTOMIZE}
 
@@ -82,19 +78,53 @@ kubectl apply -n "${NAMESPACE}" -f "${ARGOCD_YAML}"
 if [[ "${CLUSTER_TYPE}" == "openshift" ]] || [[ "${CLUSTER_TYPE}" == "ocp3" ]] || [[ "${CLUSTER_TYPE}" == "ocp4" ]]; then
   sleep 5
 
-  oc project ${NAMESPACE}
-  oc create route edge argocd --service=argocd-server --port=https --insecure-policy=Redirect
+  oc create route passthrough argocd --service=argocd-server --port=https --insecure-policy=Redirect -n "${NAMESPACE}"
 
   HOST=$(oc get route argocd -n "${NAMESPACE}" -o jsonpath='{ .spec.host }')
 
   URL="https://${HOST}"
+
+  DEX_TOKEN=$(oc serviceaccounts get-token argocd-dex-server)
+  OAUTH_URL="https://${HOST}/api/dex/callback"
+  SERVER_URL=$(oc whoami --show-server)
+
+  oc patch serviceaccount argocd-dex-server -n "${NAMESPACE}" --type='json' -p="[{\"op\": \"add\", \"path\": \"/metadata/annotations/serviceaccounts.openshift.io~1oauth-redirecturi.argocd\", \"value\":\"${OAUTH_URL\"}]"
+
+  cat > "${MODULE_DIR}/argocd-url-patch.yaml" << EOL
+data:
+  url: ${URL}
+EOL
+
+  kubectl patch configmap argocd-cm --type merge --patch "$(cat ${MODULE_DIR}/argocd-url-patch.yaml)"
+
+  cat > "${MODULE_DIR}/argocd-dex-patch.yaml" << EOL
+data:
+  dex.config: |
+    connectors:
+    - type: openshift
+      id: openshift
+      name: OpenShift
+      config:
+        issuer: ${SERVER_URL}
+        clientID: system:serviceaccount:${NAMESPACE}:argocd-dex-server
+        clientSecret: ${DEV_TOKEN}
+        redirectURI: ${OAUTH_URL}
+        insecureCA: true
+EOL
+
+  # don't apply this patch right now
+  #kubectl patch configmap argocd-cm --type merge --patch "$(cat ${MODULE_DIR}/argocd-dex-patch.yaml)"
 fi
 
 sleep 5
 PASSWORD=$(kubectl get pods -n tools -l app.kubernetes.io/name=argocd-server -o jsonpath='{.items[0].metadata.name}')
 
+helm3 repo add toolkit-charts https://ibm-garage-cloud.github.io/toolkit-charts/
+helm3 template argocd-config toolkit-charts/tool-config \
+  --namespace "${NAMESPACE}" \
+  --set name=argocd \
+  --set username=admin \
+  --set password="${PASSWORD}" \
+  --set url="${URL}" > "${SECRET_OUTPUT_YAML}"
 
-if [[ ! $(command -v igc) ]]; then
-  npm i -g @ibmgaragecloud/cloud-native-toolkit-cli
-fi
-igc tool-config --name argocd --url "${URL}" --username admin --password "${PASSWORD}"
+kubectl apply -n "${NAMESPACE}" -f "${SECRET_OUTPUT_YAML}"

--- a/generic/tools/argocd_release/variables.tf
+++ b/generic/tools/argocd_release/variables.tf
@@ -27,7 +27,7 @@ variable "tls_secret_name" {
 variable "helm_version" {
   type        = string
   description = "The version of helm chart that should be deployed"
-  default     = "1.0.0"
+  default     = "1.8.7"
 }
 
 # If enable_cache is not set to true, then Argo will not be able to synchronize


### PR DESCRIPTION
- Updates module to use helm3 for install
- Fixes crd install for helm3 to use includeCRDs flag
- Includes logic for ArgoCD OAuth integration with OpenShift (wip, currently disabled)

Addresses ibm-garage-cloud/planning#72