### PR TITLE
Dashboard module: Bumps image version to 1.0.22 for pactbroker change

### DIFF
--- a/generic/tools/developerdashboard_release/variables.tf
+++ b/generic/tools/developerdashboard_release/variables.tf
@@ -33,5 +33,5 @@ variable "tls_secret_name" {
 variable "image_tag" {
   type        = string
   description = "The image version tag to use"
-  default     = "1.0.21"
+  default     = "1.0.22"
 }


### PR DESCRIPTION
ibm-garage-cloud/planning#132