### PR TITLE
IBM Cloud cluster module: Update terraform dependencies on output

### DIFF
--- a/cloud-managed/cluster/ibmcloud/outputs.tf
+++ b/cloud-managed/cluster/ibmcloud/outputs.tf
@@ -7,32 +7,37 @@ output "id" {
 output "name" {
   value       = local.cluster_name
   description = "Name of the cluster."
+  depends_on  = [helm_release.ibmcloud_config]
 }
 
 output "resource_group_name" {
   value       = var.resource_group_name
   description = "Name of the resource group containing the cluster."
+  depends_on  = [helm_release.ibmcloud_config]
 }
 
 output "region" {
   value       = var.cluster_region
   description = "Region containing the cluster."
+  depends_on  = [helm_release.ibmcloud_config]
 }
 
 output "ingress_hostname" {
   value       = local.ingress_hostname
   description = "Ingress hostname of the cluster."
+  depends_on  = [helm_release.ibmcloud_config]
 }
 
 output "server_url" {
   value       = local.server_url
   description = "The url of the control server."
+  depends_on  = [helm_release.ibmcloud_config]
 }
 
 output "config_file_path" {
   value       = "${local.cluster_config_dir}/config"
   description = "Path to the config file for the cluster."
-  depends_on  = [null_resource.oc_login, null_resource.setup_kube_config]
+  depends_on  = [helm_release.ibmcloud_config]
 }
 
 output "type" {
@@ -50,26 +55,29 @@ output "version" {
 output "login_user" {
   value       = var.login_user
   description = "The username used to log into the openshift cli"
+  depends_on  = [helm_release.ibmcloud_config]
 }
 
 output "login_password" {
-  depends_on  = [null_resource.oc_login]
   value       = var.ibmcloud_api_key
   description = "The password used to log into the openshift cli"
+  depends_on  = [helm_release.ibmcloud_config]
 }
 
 output "ibmcloud_api_key" {
-  depends_on  = [null_resource.oc_login]
   value       = var.ibmcloud_api_key
   description = "The API key for the environment"
+  depends_on  = [helm_release.ibmcloud_config]
 }
 
 output "tls_secret_name" {
   value       = local.tls_secret
   description = "The name of the secret containin the tls information for the cluster"
+  depends_on  = [helm_release.ibmcloud_config]
 }
 
 output "tag" {
   value       = local.cluster_type_tag
   description = "The tag vased on the cluster type"
+  depends_on  = [helm_release.ibmcloud_config]
 }


### PR DESCRIPTION
- Some downstream modules are executing before the helm chart has been created, particularly the namespace modules that copies the configmap into other namespaces (ibm-garage-cloud/ibm-garage-cloud-cli#15)