### PR TITLE
Namespace: Updates output dependencies to fix timing issue 

### DIFF
--- a/generic/cluster/namespaces/main.tf
+++ b/generic/cluster/namespaces/main.tf
@@ -47,19 +47,6 @@ resource "kubernetes_namespace" "releases" {
   }
 }
 
-resource "null_resource" "copy_tls_secrets" {
-  depends_on = [kubernetes_namespace.tools, kubernetes_namespace.releases]
-  count      = length(local.namespaces)
-
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/copy-secret-to-namespace.sh \"${var.tls_secret_name}\" ${local.namespaces[count.index]}"
-
-    environment = {
-      KUBECONFIG = var.cluster_config_file_path
-    }
-  }
-}
-
 resource "null_resource" "copy_apikey_secret" {
   depends_on = [kubernetes_namespace.tools, kubernetes_namespace.releases]
   count      = length(local.namespaces)

--- a/generic/cluster/namespaces/outputs.tf
+++ b/generic/cluster/namespaces/outputs.tf
@@ -1,11 +1,19 @@
 output "tools_namespace_name" {
   value       = var.tools_namespace
   description = "Namespace where development tools will be deployed"
-  depends_on  = [kubernetes_namespace.tools]
+  depends_on  = [
+    null_resource.create_pull_secrets,
+    null_resource.copy_cloud_configmap,
+    null_resource.copy_apikey_secret
+  ]
 }
 
 output "release_namespaces" {
   value       = var.release_namespaces
   description = "Namespaces where applications will be deployed"
-  depends_on  = [kubernetes_namespace.releases]
+  depends_on  = [
+    null_resource.create_pull_secrets,
+    null_resource.copy_cloud_configmap,
+    null_resource.copy_apikey_secret
+  ]
 }


### PR DESCRIPTION
(ibm-garage-cloud/planning#219)

- Makes output values depend on pull secrets, ibmcloud configmap, and ibmcloud apikey
- Removes unneeded `copy_tls_secret` resource (the cluster makes the tls secret available somehow in all namespaces and will only renew the one in the default namespace)